### PR TITLE
modified:   makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,2 +1,2 @@
 blackjack: blackjack.cpp
-	clang -o blackjack -cstd
+	clang++ blackjack.cpp -o blackjack

--- a/makefile
+++ b/makefile
@@ -1,2 +1,2 @@
 blackjack: blackjack.cpp
-	clang++ blackjack.cpp -o blackjack
+	clang++ -o blackjack blackjack.cpp -std=c++14


### PR DESCRIPTION
Hi there,

I encountered an issue while trying to compile the project using the provided makefile on linux. The original makefile specifies the -cstd flag, which is causing an error on Linux systems. I've made a simple fix to update the makefile to specify the `-std=c++14` flag instead, and use `clang++` which resolves the issue.

+ Error Message:
When running the original makefile on Linux, I encountered the following error:
```
$ make
clang -o blackjack -cstd
clang-16: error: unknown argument: '-cstd'
clang-16: error: no input files
make: *** [makefile:2: blackjack] Error 1
```
+ Updated makefile:
```
blackjack: blackjack.cpp
    clang++ -o blackjack blackjack.cpp -std=c++14
```